### PR TITLE
CRITICAL: infer sampling period when sampling period is not provided

### DIFF
--- a/autokoopman/autokoopman.py
+++ b/autokoopman/autokoopman.py
@@ -119,7 +119,7 @@ def get_estimator(obs_type, sampling_period, dim, obs, hyperparams):
 def auto_koopman(
     training_data: Union[TrajectoriesData, Sequence[np.ndarray]],
     inputs_training_data: Optional[Sequence[np.ndarray]] = None,
-    sampling_period: float = 0.05,
+    sampling_period: Optional[float] = None,
     opt: Union[str, HyperparameterTuner] = "monte-carlo",
     max_opt_iter: int = 100,
     max_epochs: int = 500,
@@ -195,7 +195,7 @@ def auto_koopman(
             # 'estimator': <autokoopman.estimator.koopman.KoopmanDiscEstimator at 0x7f0f92ff0610>}
     """
 
-    training_data = _sanitize_training_data(
+    training_data, sampling_period = _sanitize_training_data(
         training_data, inputs_training_data, sampling_period, opt, obs_type
     )
 
@@ -341,6 +341,13 @@ def _sanitize_training_data(
     training_data, inputs_training_data, sampling_period, opt, obs_type
 ):
     """auto_koopman input sanitization"""
+
+    # if sampling period is None AND discrete system is wanted
+    if sampling_period is None:
+        sampling_period = np.infty
+        for t in training_data:
+            sampling_period = min(sampling_period, min(np.diff(t.times)))
+
     # sanitize the input
     # check the strings
     if isinstance(obs_type, str):
@@ -380,4 +387,4 @@ def _sanitize_training_data(
                 }
             )
 
-    return training_data
+    return training_data, sampling_period


### PR DESCRIPTION
@Abdu-Hekal @KochdumperNiklas gents, this has been ruining the benchmarks real data script. When the sampling period was not provided, `auto_koopman` was not choosing a good (valid) sampling period. Also, bopt now uses the loglinear attributes, so it's better overall. Please merge/rebase on `benchmarks` branch.

Also, is [mean_absolute_percentage_error](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_percentage_error.html) really what we want? I see the documentation says
```python
>>> # the value when some element of the y_true is zero is arbitrarily high because
>>> # of the division by epsilon
>>> y_true = [1., 0., 2.4, 7.]
>>> y_pred = [1.2, 0.1, 2.4, 8.]
>>> mean_absolute_percentage_error(y_true, y_pred)
112589990684262.48
```