### PR TITLE
Fix Bad Sampling Periods in Hyperparameter Tuner

### DIFF
--- a/autokoopman/autokoopman.py
+++ b/autokoopman/autokoopman.py
@@ -377,7 +377,12 @@ def _sanitize_training_data(
     # convert the data to autokoopman trajectories
     if isinstance(training_data, TrajectoriesData):
         if not isinstance(training_data, UniformTimeTrajectoriesData):
+            print(f"resampling trajectories as they need to be uniform time (sampling period {sampling_period})")
             training_data = training_data.interp_uniform_time(sampling_period)
+        else:
+            if not np.isclose(training_data.sampling_period, sampling_period):
+                print(f"resampling trajectories because the sampling periods differ (original {training_data.sampling_period}, new {sampling_period})")
+                training_data = training_data.interp_uniform_time(sampling_period)
     else:
         # figure out how to add inputs
         training_iter = (

--- a/autokoopman/core/system.py
+++ b/autokoopman/core/system.py
@@ -360,13 +360,12 @@ class KoopmanSystem:
     """
     mixin class for Koopman systems
     """
-
-    def __init__(self, A, B, obs, names):
+    def __init__(self, A, B, obs, names, dim=None):
         self._A = A
         self._B = B
         self._has_input = not np.any(np.array(B.shape) == 0)
         self.obs = obs
-        self.dim = A.shape[0]
+        self.dim = A.shape[0] if dim is None else dim
 
         def evolv_func(t, x, i):
             obs = (self.obs(x).flatten())[np.newaxis, :]

--- a/autokoopman/core/system.py
+++ b/autokoopman/core/system.py
@@ -363,7 +363,7 @@ class KoopmanSystem:
     def __init__(self, A, B, obs, names, dim=None):
         self._A = A
         self._B = B
-        self._has_input = not np.any(np.array(B.shape) == 0)
+        self._has_input = B is not None and not np.any(np.array(B.shape) == 0)
         self.obs = obs
         self.dim = A.shape[0] if dim is None else dim
 

--- a/autokoopman/core/tuner.py
+++ b/autokoopman/core/tuner.py
@@ -178,13 +178,18 @@ class HyperparameterTuner(abc.ABC):
         preds = {}
         # get the predictions
         for k, v in holdout_data._trajs.items():
+            # ugh, this is a hack--sampling period is meaningful if the system is discrete
+            # TODO: make the behavior of sampling period less problematic
+            _kwargs = {}
+            if hasattr(v, "sampling_period"):
+                _kwargs["sampling_period"] = v.sampling_period
             sivp_interp = trained_model.model.solve_ivp(
                 v.states[0],
                 (np.min(v.times), np.max(v.times)),
                 inputs=v.inputs,
                 teval=v.times,
+                **_kwargs
             )
-            # sivp_interp = sivp_interp.interp1d(v.times)
             preds[k] = sivp_interp
         return TrajectoriesData(preds)
 

--- a/autokoopman/estimator/koopman.py
+++ b/autokoopman/estimator/koopman.py
@@ -74,16 +74,7 @@ class KoopmanDiscEstimator(kest.NextStepEstimator):
         """
         packs the learned linear transform into a discrete linear system
         """
-        def step_func(t, x, i):
-            obs = (self.obs(x).flatten())[np.newaxis, :]
-            if self._has_input:
-                return np.real(
-                    self._A @ obs.T + self._B @ (i)[:, np.newaxis]
-                ).flatten()[: self.dim]
-            else:
-                return np.real(self._A @ obs.T).flatten()[: len(x)]
-
-        return ksys.KoopmanStepDiscreteSystem(self._A, self._B, self.obs, self.names)#(step_func, self.names)
+        return ksys.KoopmanStepDiscreteSystem(self._A, self._B, self.obs, self.names, self.dim)
 
 
 class KoopmanContinuousEstimator(kest.GradientEstimator):
@@ -124,14 +115,4 @@ class KoopmanContinuousEstimator(kest.GradientEstimator):
         """
         packs the learned linear transform into a continuous linear system
         """
-
-        def grad_func(t, x, i):
-            obs = (self.obs(x).flatten())[np.newaxis, :]
-            if self._has_input:
-                return np.real(
-                    self._A @ obs.T + self._B @ (i)[:, np.newaxis]
-                ).flatten()[: self.dim]
-            else:
-                return np.real(self._A @ obs.T).flatten()[: len(x)]
-
-        return ksys.KoopmanGradientContinuousSystem(self._A, self._B, self.obs, self.names)#grad_func, self.names)
+        return ksys.KoopmanGradientContinuousSystem(self._A, self._B, self.obs, self.names, self.dim)#grad_func, self.names)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=falsification


### PR DESCRIPTION
From #52 , the hyperparameter tuner will use bad sampling periods when tuning against a re-sampled model. This patch corrects this. However, this is a result of counterintuitive interface design, and should likely be addressed by tweaking the class interfaces.

CC @Abdu-Hekal feel free to cherry-pick or merge. I ran it against your script for validation.