### PR TITLE
Quickfix: Fix documentation CI/CD

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Sphinx Build
 on: [push, pull_request, workflow_dispatch]
 jobs:
   docs:
-    if: github.ref == 'refs/heads/develop'
+    if: {{ github.ref == 'refs/heads/develop' ||  github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fix documentation GH action so it publishes when tag release occurs.